### PR TITLE
Request Factory fixes

### DIFF
--- a/src/RequestFactory.cpp
+++ b/src/RequestFactory.cpp
@@ -87,7 +87,6 @@ void RequestFactory::parse()
 
     if (m_active_status == RequestFactory::HEADER)
     {
-        std::cout << "headers" << std::endl;
         std::string line;
         while (m_buffer.find('\n') != std::string::npos)
         {
@@ -125,13 +124,12 @@ void RequestFactory::parse()
             {
                 m_req_buffer.push(m_active_req);
                 m_active_status = RequestFactory::REQ_LINE;
+                return;
             }
         }
-        return;
     }
     if (m_active_status == RequestFactory::BODY)
     {
-        std::cout << "body" << std::endl;
         if (m_body_type == RequestFactory::LENGTH)
         {
             std::stringstream ss;

--- a/src/RequestFactory.cpp
+++ b/src/RequestFactory.cpp
@@ -167,8 +167,13 @@ RequestFactory& RequestFactory::operator=(const RequestFactory& copy)
 
 void RequestFactory::in(const std::string& str)
 {
+    std::size_t buf_size = m_buffer.length();
     m_buffer += str;
-    parse();
+    while (buf_size != m_buffer.length()) // Checks if the length changes while parsing
+    {
+        buf_size = m_buffer.length();
+        parse();
+    }
 }
 bool RequestFactory::isReqReady() const { return !m_req_buffer.empty(); }
 HttpRequest RequestFactory::getRequest()

--- a/src/Router.cpp
+++ b/src/Router.cpp
@@ -263,14 +263,13 @@ void Router::listen()
                         event_map[events[i].data.fd].rf.in(s);
                     }
 
-                    std::cout << "handling new request on: " << events[i].data.fd << std::endl;
+                    std::cout << "handling new data on: " << events[i].data.fd << std::endl;
 
 
                     if (event_map[events[i].data.fd].rf.isReqReady())
                     {
                         HttpResponse res;
                         HttpRequest req = event_map[events[i].data.fd].rf.getRequest();
-                        std::cout << "req: \n" << req.toString() << std::endl;
                         std::cout << "Made request" << std::endl;
                         // Figure out which server this request belongs to
                         if (event_map[events[i].data.fd].server == NULL) {

--- a/src/Router.cpp
+++ b/src/Router.cpp
@@ -270,6 +270,7 @@ void Router::listen()
                     {
                         HttpResponse res;
                         HttpRequest req = event_map[events[i].data.fd].rf.getRequest();
+                        std::cout << "req: \n" << req.toString() << std::endl;
                         std::cout << "Made request" << std::endl;
                         // Figure out which server this request belongs to
                         if (event_map[events[i].data.fd].server == NULL) {

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -78,9 +78,10 @@ HttpResponse    Server::handleRequest(const HttpRequest& req)
     else if (req.method() == "HEAD")
         return response_head(req, path, res, _cfg, route);
 
-    // TODO: check for CGI
+    else
+        return response_error(req, res, _cfg, route, 501);
 
-    return res;
+    // TODO: check for CGI
 }
 
 ServerCfg&  Server::cfg()


### PR DESCRIPTION
- Requests with a body now get properly parsed.
- It can handle multiple requests on 1 call of `in`.
- We now return a 501 when the request method is not implemented/recognized.

